### PR TITLE
[Donggi + Miller] 웹서버 3단계 - POST로 회원 가입

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,33 @@ Java Web Server Project for CodeSquad Members 2022
 
 ### 프로그래밍 요구사항
 
-- [X] 회원가입을 하면 다음과 같은 형태로 사용자가 입력한 값이 서버에 전달된다. 
+- [X] 회원가입을 하면 다음과 같은 형태로 사용자가 입력한 값이 서버에 전달된다.
   ```
   /create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net
   ```
 - [X] HTML과 URL을 비교해 보고 사용자가 입력한 값을 파싱해 model.User 클래스에 저장한다.
 - [X] 한글이 정확하게 입력되고 있는지 확인해야 한다.
+
+<br/>
+</div>
+</details>
+
+<br/>
+<details>
+<summary>👌 웹서버 3 단계 - GET으로 회원가입 기능 구현</summary>
+<div markdown="1">
+<br/>
+
+### 기능요구사항
+
+- [X] http://localhost:8080/user/form.html 파일의 HTML form을 통해 회원가입을 할 수 있다.
+- [X] 가입 후 index.html 페이지로 이동한다.
+
+### 프로그래밍 요구사항
+
+- [X] http://localhost:8080/user/form.html 파일의 form 태그 method를 get에서 post로 수정한다.
+- [X] POST로 회원가입 기능이 정상적으로 동작하도록 구현한다.
+- [X] 가입 후 페이지 이동을 위해 redirection 기능을 구현한다.
 
 <br/>
 </div>

--- a/src/main/java/db/DataBase.java
+++ b/src/main/java/db/DataBase.java
@@ -1,21 +1,21 @@
 package db;
 
+import com.google.common.collect.Maps;
 import java.util.Collection;
 import java.util.Map;
-
-import com.google.common.collect.Maps;
-
+import java.util.Optional;
 import model.User;
 
 public class DataBase {
-    private static Map<String, User> users = Maps.newHashMap();
+
+    private static final Map<String, User> users = Maps.newHashMap();
 
     public static void addUser(User user) {
         users.put(user.getUserId(), user);
     }
 
-    public static User findUserById(String userId) {
-        return users.get(userId);
+    public static Optional<User> findUserById(String userId) {
+        return Optional.ofNullable(users.get(userId));
     }
 
     public static Collection<User> findAll() {

--- a/src/main/java/util/HttpRequestUtils.java
+++ b/src/main/java/util/HttpRequestUtils.java
@@ -1,14 +1,13 @@
 package util;
 
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-
-import com.google.common.base.Strings;
-import com.google.common.collect.Maps;
 
 public class HttpRequestUtils {
     /**
@@ -33,11 +32,9 @@ public class HttpRequestUtils {
         if (Strings.isNullOrEmpty(values)) {
             return Maps.newHashMap();
         }
-
         String decoded = URLDecoder.decode(values, StandardCharsets.UTF_8);
 
-        String[] tokens = decoded.split(separator);
-        return Arrays.stream(tokens)
+        return Arrays.stream(decoded.split(separator))
             .map(t -> getKeyValue(t, "="))
             .filter(Objects::nonNull)
             .collect(Collectors.toMap(Pair::getKey, Pair::getValue));

--- a/src/main/java/webserver/Request.java
+++ b/src/main/java/webserver/Request.java
@@ -14,8 +14,9 @@ public class Request {
     private final ContentType contentType;
 
     private final Map<String, String> headers;
+    private final Map<String, String> body;
 
-    public Request(String line, Map<String, String> headers) {
+    public Request(String line, Map<String, String> headers, Map<String, String> body) {
         String[] tokens = line.split(" ");
         method = tokens[0];
         url = tokens[1];
@@ -26,6 +27,11 @@ public class Request {
         contentType = toContentType();
 
         this.headers = headers;
+        this.body = body;
+    }
+
+    public Request(String line, Map<String, String> header) {
+        this(line, header, null);
     }
 
     public String parsePath() {
@@ -69,5 +75,9 @@ public class Request {
 
     public Map<String, String> getHeaders() {
         return headers;
+    }
+
+    public Map<String, String> getBody() {
+        return body;
     }
 }

--- a/src/main/java/webserver/Request.java
+++ b/src/main/java/webserver/Request.java
@@ -65,19 +65,20 @@ public class Request {
         return path;
     }
 
-    public Map<String, String> getQueryString() {
-        return queryString;
+    public String getQueryStringValue(String parameter) {
+        return queryString.get(parameter);
     }
 
     public ContentType getContentType() {
         return contentType;
     }
 
-    public Map<String, String> getHeaders() {
-        return headers;
+    public String getHeaderValue(String key) {
+        return headers.get(key);
     }
 
-    public Map<String, String> getBody() {
-        return body;
+    public String getBodyValue(String key) {
+        return body.get(key);
     }
+
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -48,5 +48,4 @@ public class RequestHandler extends Thread {
     private Response handlePath(Request request) {
         return pathMapper.callHandler(request);
     }
-
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -69,15 +69,14 @@ public class RequestHandler extends Thread {
     }
 
     private void createUser(Request request) {
-        Map<String, String> queryString = request.getQueryString();
+        Map<String, String> body = request.getBody();
 
         User user = new User(
-            queryString.get("userId"),
-            queryString.get("password"),
-            queryString.get("name"),
-            queryString.get("email")
+                body.get("userId"),
+                body.get("password"),
+                body.get("name"),
+                body.get("email")
         );
         log.info("user={}", user);
     }
-
 }

--- a/src/main/java/webserver/Response.java
+++ b/src/main/java/webserver/Response.java
@@ -10,9 +10,9 @@ public class Response {
 
     private static final Logger log = LoggerFactory.getLogger(Response.class);
 
-    private Status status;
-    private Map<String, String> header;
-    private byte[] body;
+    private final Status status;
+    private final Map<String, String> header;
+    private final byte[] body;
 
     public Response(Status status, Map<String, String> header, byte[] body) {
         this.status = status;

--- a/src/main/java/webserver/ResponseWriter.java
+++ b/src/main/java/webserver/ResponseWriter.java
@@ -11,7 +11,7 @@ public class ResponseWriter {
 
     private static final Logger log = LoggerFactory.getLogger(ResponseWriter.class);
 
-    private DataOutputStream dos;
+    private final DataOutputStream dos;
 
     public ResponseWriter(DataOutputStream dos) {
         this.dos = dos;

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -2,16 +2,15 @@ package webserver;
 
 import java.net.ServerSocket;
 import java.net.Socket;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.handler.PathMapper;
-import webserver.handler.PathMapperFactory;
+import webserver.handler.PathMapperFactoryImpl;
 
 public class WebServer {
     private static final Logger log = LoggerFactory.getLogger(WebServer.class);
 
-    private static final PathMapper pathMapper = PathMapperFactory.create();
+    private static final PathMapper pathMapper = new PathMapperFactoryImpl().create();
     private static final int DEFAULT_PORT = 8080;
 
     public static void main(String args[]) throws Exception {

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -5,9 +5,12 @@ import java.net.Socket;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.handler.PathMapper;
 
 public class WebServer {
     private static final Logger log = LoggerFactory.getLogger(WebServer.class);
+
+    private static final PathMapper pathMapper = new PathMapper();
     private static final int DEFAULT_PORT = 8080;
 
     public static void main(String args[]) throws Exception {
@@ -26,7 +29,7 @@ public class WebServer {
             // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
             while ((connection = listenSocket.accept()) != null) {
-                RequestHandler requestHandler = new RequestHandler(connection);
+                RequestHandler requestHandler = new RequestHandler(connection, pathMapper);
                 requestHandler.start();
             }
         }

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -6,11 +6,12 @@ import java.net.Socket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.handler.PathMapper;
+import webserver.handler.PathMapperFactory;
 
 public class WebServer {
     private static final Logger log = LoggerFactory.getLogger(WebServer.class);
 
-    private static final PathMapper pathMapper = new PathMapper();
+    private static final PathMapper pathMapper = PathMapperFactory.create();
     private static final int DEFAULT_PORT = 8080;
 
     public static void main(String args[]) throws Exception {

--- a/src/main/java/webserver/handler/DefaultFileHandler.java
+++ b/src/main/java/webserver/handler/DefaultFileHandler.java
@@ -1,0 +1,37 @@
+package webserver.handler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import webserver.Request;
+import webserver.Response;
+import webserver.Status;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+public class DefaultFileHandler implements PathHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultFileHandler.class);
+    private static final String WEBAPP_PATH = "./webapp";
+
+    @Override
+    public Response handle(Request request) {
+        try {
+            byte[] body = readFile(request);
+            return new Response.Builder(Status.OK)
+                    .addHeader("Content-Type", request.getContentType().getMime())
+                    .addHeader("Content-Length", String.valueOf(body.length))
+                    .body(body)
+                    .build();
+
+        } catch (IOException e) {
+            log.error(e.getMessage());
+        }
+        return null;
+    }
+
+    private byte[] readFile(Request request) throws IOException {
+        return Files.readAllBytes(new File(WEBAPP_PATH + request.parsePath()).toPath());
+    }
+}

--- a/src/main/java/webserver/handler/Pair.java
+++ b/src/main/java/webserver/handler/Pair.java
@@ -1,0 +1,37 @@
+package webserver.handler;
+
+import webserver.Request;
+
+import java.util.Objects;
+
+public class Pair {
+    private final String method;
+    private final String path;
+
+    public Pair(String method, String path) {
+        this.method = method;
+        this.path = path;
+    }
+
+    public static Pair from(Request request) {
+        return new Pair(request.getMethod(), request.getPath());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || o.getClass() != getClass()) {
+            return false;
+        }
+
+        Pair pair = (Pair) o;
+        return method.equals(pair.method) && path.equals(pair.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(method, path);
+    }
+}

--- a/src/main/java/webserver/handler/PathHandler.java
+++ b/src/main/java/webserver/handler/PathHandler.java
@@ -1,0 +1,9 @@
+package webserver.handler;
+
+import webserver.Request;
+import webserver.Response;
+
+public interface PathHandler {
+
+    Response handle(Request request);
+}

--- a/src/main/java/webserver/handler/PathMapper.java
+++ b/src/main/java/webserver/handler/PathMapper.java
@@ -3,18 +3,19 @@ package webserver.handler;
 import webserver.Request;
 import webserver.Response;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
 public class PathMapper {
 
-    private static final Map<Pair, PathHandler> requestMap = new HashMap<>();
-    private static final PathHandler defaultFileHandler = new DefaultFileHandler();
 
-    static {
-        requestMap.put(new Pair("POST", "/user/create"), new UserCreateHandler());
+    private final Map<Pair, PathHandler> requestMap;
+    private final PathHandler defaultFileHandler;
+
+    public PathMapper(Map<Pair, PathHandler> requestMap, PathHandler defaultFileHandler) {
+        this.requestMap = requestMap;
+        this.defaultFileHandler = defaultFileHandler;
     }
 
     public Response callHandler(Request request) {
@@ -25,35 +26,4 @@ public class PathMapper {
         return pathHandler.handle(request);
     }
 
-    private static class Pair {
-        private final String method;
-        private final String path;
-
-        public Pair(String method, String path) {
-            this.method = method;
-            this.path = path;
-        }
-
-        public static Pair from(Request request) {
-            return new Pair(request.getMethod(), request.getPath());
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || o.getClass() != getClass()) {
-                return false;
-            }
-
-            Pair pair = (Pair) o;
-            return method.equals(pair.method) && path.equals(pair.path);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(method, path);
-        }
-    }
 }

--- a/src/main/java/webserver/handler/PathMapper.java
+++ b/src/main/java/webserver/handler/PathMapper.java
@@ -1,0 +1,59 @@
+package webserver.handler;
+
+import webserver.Request;
+import webserver.Response;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public class PathMapper {
+
+    private static final Map<Pair, PathHandler> requestMap = new HashMap<>();
+    private static final PathHandler defaultFileHandler = new DefaultFileHandler();
+
+    static {
+        requestMap.put(new Pair("POST", "/user/create"), new UserCreateHandler());
+    }
+
+    public Response callHandler(Request request) {
+        Pair pair = Pair.from(request);
+        PathHandler pathHandler = Optional.ofNullable(requestMap.get(pair))
+                .orElse(defaultFileHandler);
+
+        return pathHandler.handle(request);
+    }
+
+    private static class Pair {
+        private final String method;
+        private final String path;
+
+        public Pair(String method, String path) {
+            this.method = method;
+            this.path = path;
+        }
+
+        public static Pair from(Request request) {
+            return new Pair(request.getMethod(), request.getPath());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || o.getClass() != getClass()) {
+                return false;
+            }
+
+            Pair pair = (Pair) o;
+            return method.equals(pair.method) && path.equals(pair.path);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(method, path);
+        }
+    }
+}

--- a/src/main/java/webserver/handler/PathMapper.java
+++ b/src/main/java/webserver/handler/PathMapper.java
@@ -1,27 +1,25 @@
 package webserver.handler;
 
+import java.util.Map;
+import java.util.Optional;
 import webserver.Request;
 import webserver.Response;
-
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 
 public class PathMapper {
 
 
-    private final Map<Pair, PathHandler> requestMap;
+    private final Map<Pair, PathHandler> handlerMap;
     private final PathHandler defaultFileHandler;
 
-    public PathMapper(Map<Pair, PathHandler> requestMap, PathHandler defaultFileHandler) {
-        this.requestMap = requestMap;
+    public PathMapper(Map<Pair, PathHandler> handlerMap, PathHandler defaultFileHandler) {
+        this.handlerMap = handlerMap;
         this.defaultFileHandler = defaultFileHandler;
     }
 
     public Response callHandler(Request request) {
         Pair pair = Pair.from(request);
-        PathHandler pathHandler = Optional.ofNullable(requestMap.get(pair))
-                .orElse(defaultFileHandler);
+        PathHandler pathHandler = Optional.ofNullable(handlerMap.get(pair))
+            .orElse(defaultFileHandler);
 
         return pathHandler.handle(request);
     }

--- a/src/main/java/webserver/handler/PathMapperFactory.java
+++ b/src/main/java/webserver/handler/PathMapperFactory.java
@@ -1,16 +1,7 @@
 package webserver.handler;
 
-import java.util.HashMap;
-import java.util.Map;
+public interface PathMapperFactory {
 
-public class PathMapperFactory {
-
-    private static Map<Pair, PathHandler> requestMap = new HashMap<>();
-
-    public static PathMapper create() {
-        requestMap.put(new Pair("POST", "/user/create"), new UserCreateHandler());
-
-        return new PathMapper(requestMap, new DefaultFileHandler());
-    }
+    PathMapper create();
 
 }

--- a/src/main/java/webserver/handler/PathMapperFactory.java
+++ b/src/main/java/webserver/handler/PathMapperFactory.java
@@ -1,0 +1,16 @@
+package webserver.handler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PathMapperFactory {
+
+    private static Map<Pair, PathHandler> requestMap = new HashMap<>();
+
+    public static PathMapper create() {
+        requestMap.put(new Pair("POST", "/user/create"), new UserCreateHandler());
+
+        return new PathMapper(requestMap, new DefaultFileHandler());
+    }
+
+}

--- a/src/main/java/webserver/handler/PathMapperFactoryImpl.java
+++ b/src/main/java/webserver/handler/PathMapperFactoryImpl.java
@@ -1,0 +1,15 @@
+package webserver.handler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PathMapperFactoryImpl implements PathMapperFactory {
+
+    @Override
+    public PathMapper create() {
+        Map<Pair, PathHandler> handlerMap = new HashMap<>() {{
+            put(new Pair("POST", "/user/create"), new UserCreateHandler());
+        }};
+        return new PathMapper(handlerMap, new DefaultFileHandler());
+    }
+}

--- a/src/main/java/webserver/handler/UserCreateHandler.java
+++ b/src/main/java/webserver/handler/UserCreateHandler.java
@@ -10,16 +10,31 @@ public class UserCreateHandler implements PathHandler {
 
     @Override
     public Response handle(Request request) {
-        User user = new User(
-            request.getBodyValue("userId"),
-            request.getBodyValue("password"),
-            request.getBodyValue("name"),
-            request.getBodyValue("email")
-        );
-        DataBase.addUser(user);
 
-        return new Response.Builder(Status.FOUND)
-            .addHeader("Location", "http://localhost:8080/index.html")
-            .build();
+        try {
+            DataBase.findUserById(request.getBodyValue("userId"))
+                .ifPresent((findUser) -> {
+                    throw new IllegalArgumentException("중복된 유저입니다.");
+                });
+
+            User user = new User(
+                request.getBodyValue("userId"),
+                request.getBodyValue("password"),
+                request.getBodyValue("name"),
+                request.getBodyValue("email")
+            );
+            DataBase.addUser(user);
+
+            return new Response.Builder(Status.FOUND)
+                .addHeader("Location", "http://localhost:8080/index.html")
+                .build();
+
+        } catch (IllegalArgumentException e) {
+            return new Response.Builder(Status.FOUND)
+                .addHeader("Location", "http://localhost:8080/user/form.html")
+                .build();
+        }
     }
+
+
 }

--- a/src/main/java/webserver/handler/UserCreateHandler.java
+++ b/src/main/java/webserver/handler/UserCreateHandler.java
@@ -1,32 +1,25 @@
 package webserver.handler;
 
+import db.DataBase;
 import model.User;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import webserver.Request;
 import webserver.Response;
 import webserver.Status;
 
-import java.util.Map;
-
 public class UserCreateHandler implements PathHandler {
-
-    private static final Logger log = LoggerFactory.getLogger(UserCreateHandler.class);
 
     @Override
     public Response handle(Request request) {
-        Map<String, String> body = request.getBody();
-
         User user = new User(
-                body.get("userId"),
-                body.get("password"),
-                body.get("name"),
-                body.get("email")
+            request.getBodyValue("userId"),
+            request.getBodyValue("password"),
+            request.getBodyValue("name"),
+            request.getBodyValue("email")
         );
-        log.info("user={}", user);
+        DataBase.addUser(user);
 
         return new Response.Builder(Status.FOUND)
-                .addHeader("Location", "http://localhost:8080/index.html")
-                .build();
+            .addHeader("Location", "http://localhost:8080/index.html")
+            .build();
     }
 }

--- a/src/main/java/webserver/handler/UserCreateHandler.java
+++ b/src/main/java/webserver/handler/UserCreateHandler.java
@@ -1,0 +1,32 @@
+package webserver.handler;
+
+import model.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import webserver.Request;
+import webserver.Response;
+import webserver.Status;
+
+import java.util.Map;
+
+public class UserCreateHandler implements PathHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(UserCreateHandler.class);
+
+    @Override
+    public Response handle(Request request) {
+        Map<String, String> body = request.getBody();
+
+        User user = new User(
+                body.get("userId"),
+                body.get("password"),
+                body.get("name"),
+                body.get("email")
+        );
+        log.info("user={}", user);
+
+        return new Response.Builder(Status.FOUND)
+                .addHeader("Location", "http://localhost:8080/index.html")
+                .build();
+    }
+}

--- a/src/test/java/webserver/ContentTypeTest.java
+++ b/src/test/java/webserver/ContentTypeTest.java
@@ -1,0 +1,30 @@
+package webserver;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+class ContentTypeTest {
+
+    @Test
+    @DisplayName("html 확장자가 입력되면 ContentType 의 HTML 상수가 반환된다")
+    void htmlToContentTypeTest() {
+        // when
+        ContentType contentType = ContentType.from("html");
+
+        // then
+        then(contentType).isEqualTo(ContentType.HTML);
+    }
+
+    @Test
+    @DisplayName("지정되지 않은 확장자가 입력되면 ContentType 의 OTHER 상수가 반환된다")
+    void otherToContentTypeTest() {
+        // when
+        ContentType contentType = ContentType.from("ico");
+
+        // then
+        then(contentType).isEqualTo(ContentType.OTHER);
+    }
+
+}

--- a/src/test/java/webserver/RequestReaderTest.java
+++ b/src/test/java/webserver/RequestReaderTest.java
@@ -1,6 +1,5 @@
 package webserver;
 
-import static org.assertj.core.api.BDDAssertions.entry;
 import static org.assertj.core.api.BDDAssertions.then;
 
 import java.io.ByteArrayInputStream;
@@ -29,6 +28,6 @@ class RequestReaderTest {
         then(request.getMethod()).isEqualTo("GET");
         then(request.getUrl()).isEqualTo("/index.html");
         then(request.getProtocol()).isEqualTo("HTTP/1.1");
-        then(request.getHeaders()).contains(entry("Accept", "*/*"));
+        then(request.getHeaderValue("Accept")).isEqualTo("*/*");
     }
 }

--- a/src/test/java/webserver/RequestTest.java
+++ b/src/test/java/webserver/RequestTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.BDDAssertions.then;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,7 +34,7 @@ class RequestTest {
         then(request.getMethod()).isEqualTo("GET");
         then(request.getUrl()).isEqualTo("/index.html");
         then(request.getProtocol()).isEqualTo("HTTP/1.1");
-        then(request.getHeaders().get("Accept")).isEqualTo("*/*");
+        then(request.getHeaderValue("Accept")).isEqualTo("*/*");
     }
 
     @Test

--- a/src/test/java/webserver/handler/DefaultFileHandlerTest.java
+++ b/src/test/java/webserver/handler/DefaultFileHandlerTest.java
@@ -1,0 +1,56 @@
+package webserver.handler;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import webserver.Request;
+import webserver.Response;
+import webserver.Status;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+class DefaultFileHandlerTest {
+
+    Map<String, String> headers;
+    DefaultFileHandler handler;
+
+    @BeforeEach
+    public void setUp() {
+        headers = new HashMap<>() {{
+            put("Host", "localhost:8080");
+            put("Connection", "keep-alive");
+            put("Accept", "*/*");
+        }};
+
+        handler = new DefaultFileHandler();
+    }
+
+    @Test
+    @DisplayName("Request 객체가 입력되었을 때 파일을 읽어 Response 객체로 구성된다")
+    void defaultFileHandlerTest() throws IOException {
+        // given
+        String line = "GET /index.html HTTP/1.1";
+        Request request = new Request(line, headers);
+
+        byte[] body = Files.readAllBytes(new File("./webapp/index.html").toPath());
+
+        // when
+        Response response = handler.handle(request);
+
+        // then
+        then(response.getStatus()).isEqualTo(Status.OK);
+        then(response.getBody()).isEqualTo(body);
+        then(response.getHeader()).containsExactlyInAnyOrderEntriesOf(
+                new HashMap<>() {{
+                    put("Content-Type", "text/html");
+                    put("Content-Length", String.valueOf(body.length));
+                }}
+        );
+    }
+}

--- a/src/test/java/webserver/handler/PathMapperTest.java
+++ b/src/test/java/webserver/handler/PathMapperTest.java
@@ -1,0 +1,82 @@
+package webserver.handler;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import webserver.Request;
+import webserver.Response;
+import webserver.Status;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+class PathMapperTest {
+
+    Map<String, String> headers;
+    PathMapper pathMapper;
+
+    @BeforeEach
+    public void setUp() {
+        headers = new HashMap<>() {{
+            put("Host", "localhost:8080");
+            put("Connection", "keep-alive");
+            put("Accept", "*/*");
+        }};
+
+        pathMapper = new PathMapper();
+    }
+
+    @Test
+    @DisplayName("Request 객체가 입력되었을 때 DefaultFileHandler 의 handle 을 통해 Response 객체가 반환된다")
+    void pathMapperToDefaultFileHandlerTest() throws IOException {
+        // given
+        String line = "GET /index.html HTTP/1.1";
+        Request request = new Request(line, headers);
+
+        byte[] body = Files.readAllBytes(new File("./webapp/index.html").toPath());
+
+        // when
+        Response response = pathMapper.callHandler(request);
+
+        // then
+        then(response.getStatus()).isEqualTo(Status.OK);
+        then(response.getBody()).isEqualTo(body);
+        then(response.getHeader()).containsExactlyInAnyOrderEntriesOf(
+                new HashMap<>() {{
+                    put("Content-Type", "text/html");
+                    put("Content-Length", String.valueOf(body.length));
+                }}
+        );
+    }
+
+    @Test
+    @DisplayName("Request 객체가 입력되었을 때 UserCreateHandler 의 handle 을 통해 Response 객체가 반환된다")
+    void pathMapperToCreateUserHandlerTest() {
+        // given
+        String line = "POST /user/create HTTP/1.1";
+        Map<String, String> body = new HashMap<>() {{
+            put("userId", "javajigi");
+            put("password", "password");
+            put("name", "박재성");
+            put("email", "javajigi@slipp.net");
+        }};
+        Request request = new Request(line, headers, body);
+
+        // when
+        Response response = pathMapper.callHandler(request);
+
+        // then
+        then(response.getStatus()).isEqualTo(Status.FOUND);
+        then(response.getHeader()).containsExactlyInAnyOrderEntriesOf(
+                new HashMap<>() {{
+                    put("Location", "http://localhost:8080/index.html");
+                }}
+        );
+    }
+
+}

--- a/src/test/java/webserver/handler/UserCreateHandlerTest.java
+++ b/src/test/java/webserver/handler/UserCreateHandlerTest.java
@@ -1,0 +1,57 @@
+package webserver.handler;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import webserver.Request;
+import webserver.Response;
+import webserver.Status;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+
+class UserCreateHandlerTest {
+
+    Map<String, String> headers;
+    UserCreateHandler handler;
+
+    @BeforeEach
+    public void setUp() {
+        headers = new HashMap<>() {{
+            put("Host", "localhost:8080");
+            put("Connection", "keep-alive");
+            put("Accept", "*/*");
+        }};
+
+        handler = new UserCreateHandler();
+    }
+
+    @Test
+    @DisplayName("Request 객체가 입력되었을 때 User 객체를 생성하고 Response 객체를 반환한다")
+    void userCreateHandlerTest() {
+        // given
+        String line = "POST /user/create HTTP/1.1";
+        Map<String, String> body = new HashMap<>() {{
+            put("userId", "javajigi");
+            put("password", "password");
+            put("name", "박재성");
+            put("email", "javajigi@slipp.net");
+        }};
+        Request request = new Request(line, headers, body);
+
+        // when
+        Response response = handler.handle(request);
+
+        // then
+        then(response.getStatus()).isEqualTo(Status.FOUND);
+        then(response.getHeader()).containsExactlyInAnyOrderEntriesOf(
+                new HashMap<>() {{
+                    put("Location", "http://localhost:8080/index.html");
+                }}
+        );
+    }
+
+}

--- a/webapp/user/form.html
+++ b/webapp/user/form.html
@@ -75,7 +75,7 @@
 <div class="container" id="main">
    <div class="col-md-6 col-md-offset-3">
       <div class="panel panel-default content-main">
-          <form name="question" method="get" action="/user/create">
+          <form action="/user/create" method="post" name="question">
               <div class="form-group">
                   <label for="userId">사용자 아이디</label>
                   <input class="form-control" id="userId" name="userId" placeholder="User ID">


### PR DESCRIPTION
안녕하세요, 3단계 PR 을 올린 Donggi 와 Miller 입니다 🌵

이번 3단계를 진행하면서 비즈니스 요청이 들어왔을 때 처리하는 `PathHandler` 로부터,
비즈니스 로직을 분리하는데 집중했습니다.

## 3단계 요구사항

### 기능 요구사항

- [X] http://localhost:8080/user/form.html 파일의 HTML form을 통해 회원가입을 할 수 있다.
- [X] 가입 후 index.html 페이지로 이동한다.
- [X]  같은 ID로 가입을 시도할 경우 가입되지 않고 가입 페이지로 이동한다.

### 프로그래밍 요구사항

- [X] http://localhost:8080/user/form.html 파일의 form 태그 method를 get에서 post로 수정한다.
- [X] POST로 회원가입 기능이 정상적으로 동작하도록 구현한다.
- [X] 중복아이디를 처리하기 위해서 Map<Id, User> 로 회원목록을 관리한다.
- [X] 가입 후 페이지 이동을 위해 redirection 기능을 구현한다.

## 구현 세부사항

### `PathMapper`

`RequestHandler` 클래스에서 `PathMapper` 를 분리하고,
`PathMapper` 에서 클라이언트로부터 요청받은 Http Method 와 URL 에 따라 `PathHandler` 를 실행하도록 구성했습니다.
그리고 `PathHandler` 안에 비즈니스 로직을 처리하도록 분리했습니다.

### `PathMapperFactory`

`PathMapper` 내에서 URL 에 따라 `PathHandler` 를 매핑하지 않고,
별도의 `PathMapperFactory` 인터페이스와 `PathMapperFactoryImpl` 로 구현체를 만들어,
해당 클래스에서 요청에 따라 실행할 객체를 `Map` 자료 구조로 구성하고 `PathMapper` 클래스를 만들도록 변경했습니다.

### `PathMapperFactoryImpl` / `PathMapperFactoryStub`

테스트 코드 내에서는 `PathMapperFactory` 인터페이스를 구현한 `PathMapperFactoryStub` 을 만들고,
스텁 객체를 요청받은 Http Method 와 URL 에 따라 실행하도록 구성했습니다.