### PR TITLE
[피오 & 노리] 웹서버 4단계 - 쿠키를 이용한 로그인 구현

### DIFF
--- a/src/main/java/db/SessionDataBase.java
+++ b/src/main/java/db/SessionDataBase.java
@@ -10,4 +10,8 @@ public class SessionDataBase {
     public static void save(String sessionId, String userId) {
         SESSIONS.put(sessionId, userId);
     }
+
+    public static void remove(String sessionId) {
+        SESSIONS.remove(sessionId);
+    }
 }

--- a/src/main/java/db/SessionDataBase.java
+++ b/src/main/java/db/SessionDataBase.java
@@ -1,0 +1,13 @@
+package db;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SessionDataBase {
+
+    private static final Map<String, String> SESSIONS = new HashMap<>();
+
+    public static void save(String sessionId, String userId) {
+        SESSIONS.put(sessionId, userId);
+    }
+}

--- a/src/main/java/webserver/HttpRequest.java
+++ b/src/main/java/webserver/HttpRequest.java
@@ -48,4 +48,7 @@ public class HttpRequest {
         return parameters.get(key);
     }
 
+    public String getHeader(String header) {
+        return headers.get(header);
+    }
 }

--- a/src/main/java/webserver/HttpRequest.java
+++ b/src/main/java/webserver/HttpRequest.java
@@ -22,8 +22,7 @@ public class HttpRequest {
 
     private void init() throws IOException {
         String requestLine = URLDecoder.decode(br.readLine(), StandardCharsets.UTF_8);
-        String[] requestLineSplit = requestLine.split(" ");
-        this.requestLine = new RequestLine(requestLineSplit[0], requestLineSplit[1], requestLineSplit[2]);
+        this.requestLine = new RequestLine(requestLine);
         this.headers = IOUtils.readRequestHeader(br);
         this.parameters = parseParameter();
     }

--- a/src/main/java/webserver/HttpResponse.java
+++ b/src/main/java/webserver/HttpResponse.java
@@ -1,11 +1,12 @@
 package webserver;
 
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import util.IOUtils;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 
 public class HttpResponse {
 
@@ -16,6 +17,18 @@ public class HttpResponse {
 
     public HttpResponse(OutputStream out) {
         this.dos = new DataOutputStream(out);
+    }
+
+
+    public void response302WithExpiredCookieHeader(String cookie) {
+        try {
+            dos.writeBytes("HTTP/1.1 302 FOUND \r\n");
+            dos.writeBytes("Location: http://localhost:8080/index.html\r\n");
+            dos.writeBytes("Set-Cookie: sessionId=" + cookie + "; Max-Age=-1;  path=/");
+            dos.writeBytes("\r\n");
+        } catch (IOException e) {
+            log.error(e.getMessage());
+        }
     }
 
     public void response302WithCookieHeader(String cookie) {

--- a/src/main/java/webserver/HttpResponse.java
+++ b/src/main/java/webserver/HttpResponse.java
@@ -18,6 +18,26 @@ public class HttpResponse {
         this.dos = new DataOutputStream(out);
     }
 
+    public void response302WithCookieHeader(String cookie) {
+        try {
+            dos.writeBytes("HTTP/1.1 302 FOUND \r\n");
+            dos.writeBytes("Location: http://localhost:8080/index.html\r\n");
+            dos.writeBytes("Set-Cookie: sessionId=" + cookie + "; path=/");
+            dos.writeBytes("\r\n");
+        } catch (IOException e) {
+            log.error(e.getMessage());
+        }
+    }
+
+    public void response302Header(String path) {
+        try {
+            dos.writeBytes("HTTP/1.1 302 FOUND \r\n");
+            dos.writeBytes("Location: http://localhost:8080/" + path + "\r\n");
+            dos.writeBytes("\r\n");
+        } catch (IOException e) {
+            log.error(e.getMessage());
+        }
+    }
 
     public void response302Header() {
         try {

--- a/src/main/java/webserver/HttpResponse.java
+++ b/src/main/java/webserver/HttpResponse.java
@@ -1,12 +1,11 @@
 package webserver;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import util.IOUtils;
-
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import util.IOUtils;
 
 public class HttpResponse {
 
@@ -20,10 +19,10 @@ public class HttpResponse {
     }
 
 
-    public void response302WithExpiredCookieHeader(String cookie) {
+    public void response302WithExpiredCookieHeader(String path, String cookie) {
         try {
             dos.writeBytes("HTTP/1.1 302 FOUND \r\n");
-            dos.writeBytes("Location: http://localhost:8080/index.html\r\n");
+            dos.writeBytes("Location: http://localhost:8080" + path + "\r\n");
             dos.writeBytes("Set-Cookie: sessionId=" + cookie + "; Max-Age=-1;  path=/");
             dos.writeBytes("\r\n");
         } catch (IOException e) {
@@ -31,10 +30,10 @@ public class HttpResponse {
         }
     }
 
-    public void response302WithCookieHeader(String cookie) {
+    public void response302WithCookieHeader(String path, String cookie) {
         try {
             dos.writeBytes("HTTP/1.1 302 FOUND \r\n");
-            dos.writeBytes("Location: http://localhost:8080/index.html\r\n");
+            dos.writeBytes("Location: http://localhost:8080" + path + "\r\n");
             dos.writeBytes("Set-Cookie: sessionId=" + cookie + "; path=/");
             dos.writeBytes("\r\n");
         } catch (IOException e) {
@@ -45,17 +44,7 @@ public class HttpResponse {
     public void response302Header(String path) {
         try {
             dos.writeBytes("HTTP/1.1 302 FOUND \r\n");
-            dos.writeBytes("Location: http://localhost:8080/" + path + "\r\n");
-            dos.writeBytes("\r\n");
-        } catch (IOException e) {
-            log.error(e.getMessage());
-        }
-    }
-
-    public void response302Header() {
-        try {
-            dos.writeBytes("HTTP/1.1 302 FOUND \r\n");
-            dos.writeBytes("Location: http://localhost:8080/index.html\r\n");
+            dos.writeBytes("Location: http://localhost:8080" + path + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {
             log.error(e.getMessage());

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -67,8 +67,20 @@ public class RequestHandler extends Thread {
                 return;
             }
 
-            Map<String, String> cookies = HttpRequestUtils.parseCookies(
-                httpRequest.getHeader("Cookie"));
+            if (httpRequest.getPath().equals("/user/logout")) {
+                Map<String, String> cookies = HttpRequestUtils.parseCookies(
+                    httpRequest.getHeader("Cookie"));
+                String sessionId = cookies.get("sessionId");
+                log.debug("sessionId = {}", sessionId);
+                if (sessionId == null) {
+                    httpResponse.response302Header();
+                    return;
+                }
+                httpResponse.response302WithExpiredCookieHeader(sessionId);
+                SessionDataBase.remove(sessionId);
+                return;
+            }
+
             httpResponse.writeBody(httpRequest.getPath());
             httpResponse.response200Header();
             httpResponse.responseBody();

--- a/src/main/java/webserver/RequestLine.java
+++ b/src/main/java/webserver/RequestLine.java
@@ -10,10 +10,11 @@ public class RequestLine {
     private String path;
     private String httpVersion;
 
-    public RequestLine(String httpMethod, String path, String httpVersion) {
-        this.httpMethod = httpMethod;
-        this.path = path;
-        this.httpVersion = httpVersion;
+    public RequestLine(String requestLine) {
+        String[] requestLineSplit = requestLine.split(" ");
+        this.httpMethod = requestLineSplit[0];
+        this.path = requestLineSplit[1];
+        this.httpVersion = requestLineSplit[2];
     }
 
     public String getPath() {

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -71,7 +71,7 @@
                 <li><a href="#loginModal" role="button" data-toggle="modal">로그인</a></li>
                 <li><a href="#registerModal" role="button" data-toggle="modal">회원가입</a></li>
                 -->
-                <li><a href="#" role="button">로그아웃</a></li>
+                <li><a href="/user/logout" role="button">로그아웃</a></li>
                 <li><a href="#" role="button">개인정보수정</a></li>
             </ul>
         </div>


### PR DESCRIPTION
안녕하세요!! 피오 & 노리 입니다. 👬

"웹서버 4 단계 - 쿠키를 이용한 로그인 구현" 완료하여 pull request 요청드립니다. 

감사합니다! 🙇


###  3단계 리뷰 항목
- [x] 중복 회원가입 요청 처리 보완
- [x] 리다이렉션 메서드 재사용 가능하도록 보완
- [x] RequestLine 생성자 매개변수 변경


### 기능요구사항

- [x] 회원가입한 사용자로 로그인을 할 수 있어야 한다.
- [x] “로그인” 메뉴를 클릭하면 http://localhost:8080/user/login.html 으로 이동해 로그인할 수 있다.
- [x] 로그인이 성공하면 index.html로 이동하고, 로그인이 실패하면 /user/login_failed.html로 이동해야 한다.

### 프로그래밍 요구사항

- [x] 앞 단계에서 회원가입할 때 생성한 User 객체를 DataBase.addUser() 메서드를 활용해 메모리에 저장한다.
- [x] 아이디와 비밀번호가 같은지를 확인해서 로그인이 성공하면 응답 header의 Set-Cookie 값을 sessionId=적당한값으로 설정한다.
- [x] Set-Cookie 설정시 모든 요청에 대해 Cookie 처리가 가능하도록 Path 설정 값을 /(Path=/)로 설정한다.
- [x] 응답 header에 Set-Cookie값을 설정한 후 요청 header에 Cookie이 전달되는지 확인한다.

### 추가 요구 사항

- [x] (선택) 로그아웃을 구현한다.

